### PR TITLE
Fix: UI/UX updates for Navbar and JobListings, address 404 persistence

### DIFF
--- a/backend/controllers/postAnnunciController.js
+++ b/backend/controllers/postAnnunciController.js
@@ -4,11 +4,16 @@ import PostAnnunci from "../models/PostAnnunci.js";
 
 export const pubblicaLavoro = async (req, res) =>{try {
     const {titolo, azienda, descrizione, località} = req.body;
+    // Assicurati che req.user sia disponibile e contenga l'ID dell'utente autenticato
+    if (!req.user || !req.user._id) {
+        return res.status(401).json({ message: "Utente non autenticato o ID utente non trovato." });
+    }
     const newPostAnnunci = new PostAnnunci({
         titolo,
-        azienda,
+        azienda, // Considera se 'azienda' debba essere precompilato dal profilo dell'utente azienda
         descrizione,
-        località
+        località,
+        createdBy: req.user._id // Associa l'annuncio all'utente che lo crea
     });
 const annunciSalvati = await newPostAnnunci.save();
 res.status(201).json(annunciSalvati); //201 Created indica che la richiesta è andata a buon fine e ha portato alla creazione di una nuova risorsa.
@@ -61,7 +66,7 @@ export const rimuoviLavoroDaId = async(req, res) => {
 export const riceviLavoroDaAzienda = async (req, res) => {
   try {
     // Ottiene l'ID dell'utente (azienda) autenticato dalla richiesta (req.user.id).
-    const utenteId = req.utente.id;
+    const utenteId = req.user.id; // Modificato da req.utente.id a req.user.id
     // Cerca tutti gli annunci nel database dove il campo 'createdBy' corrisponde all'ID dell'utente.
     // Popola i dettagli del creatore (opzionale, ma può essere utile per conferma).
     // Ordina gli annunci per data di pubblicazione decrescente.

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -31,20 +31,19 @@ export const ensureAuthenticated = (req, res, next) => {
 
 export const ensureAuthorized = (tipoAutorizzato) => {
     return (req, res, next) => {
-         // Controlla se l'oggetto req.user esiste (l'utente è autenticato) e se ha una proprietà userType.
-         // req.utente è popolato da Passport dopo un'autenticazione riuscita (non direttamente da mongo), non di mongo
-        if (!req.utente || !req.utente.tipoUtente) {
-            return res.status(403).json({ message: "Autorizzazione fallita: utente non autenticato" });
-             // Se non matcha utente o userType, invia una risposta di errore
+         // Controlla se l'oggetto req.user esiste (l'utente è autenticato) e se ha una proprietà tipoUtente.
+         // req.user è popolato da Passport dopo un'autenticazione riuscita e deve contenere il campo come da schema Utente.js.
+        if (!req.user || !req.user.tipoUtente) { // Corretto per usare req.user.tipoUtente
+            return res.status(403).json({ message: "Autorizzazione fallita: utente non autenticato o tipo utente mancante" });
+             // Se non matcha utente o tipoUtente, invia una risposta di errore
         }
         //Usa sempre includes per controllare se un valore è presente in un array.
-        //Usa === solo per confrontare due valori (es: due stringhe).
-        //tipoAutorizzato è un array che può essere o candidato o azienda
-        //mentre tipoUtente può essere o uno o l'altro (una stringa)
+        //tipoAutorizzato è un array che può essere o 'azienda' o 'candidato' (come da schema Utente.js).
+        //mentre req.user.tipoUtente sarà una stringa come 'azienda' o 'candidato'.
         
         //controlla se il tipoUtente dell'utente autenticato è incluso nell'array tipoAutorizzato
-        if (tipoAutorizzato.includes(req.utente.tipoUtente)) {
-              // Se lo userType è consentito, passa al prossimo middleware o al gestore della rotta.
+        if (tipoAutorizzato.includes(req.user.tipoUtente)) { // Corretto per usare req.user.tipoUtente
+              // Se lo tipoUtente è consentito, passa al prossimo middleware o al gestore della rotta.
             return next(); // L'utente ha il tipo corretto, prosegui
         }
         else {

--- a/backend/models/Candidature.js
+++ b/backend/models/Candidature.js
@@ -10,9 +10,29 @@ const candidatureSchema = new mongoose.Schema({
         type: String,
         required: [true, "Inserire email"]
     },
-    descrizioneCandidato : {
+    utenteId: { // ID dell'utente che si candida
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Utente',
+        required: true
+    },
+    nome: {
+        type: String,
+        trim: true,
+        // required: [true, "Il nome è obbligatorio"] // Decidere se renderli obbligatori
+    },
+    cognome: {
+        type: String,
+        trim: true,
+        // required: [true, "Il cognome è obbligatorio"]
+    },
+    numeroTelefono: {
+        type: String,
+        trim: true,
+        // required: [true, "Il numero di telefono è obbligatorio"]
+    },
+    descrizioneCandidato : { // Usato per la lettera motivazionale o descrizione generale
         type : String, 
-        required : [true, "Inserire descrizione"]
+        required : [true, "Inserire descrizione/lettera motivazionale"]
     },
     dataCandidatura: {
         type: Date,

--- a/backend/models/PostAnnunci.js
+++ b/backend/models/PostAnnunci.js
@@ -20,6 +20,11 @@ const postAnnunciSchema = new mongoose.Schema({
     dataPubblicazione: {
         type: Date,
         default: Date.now
+    },
+    createdBy: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Utente', // Riferimento al modello Utente
+        required: [true, "Autore dell'annuncio (createdBy) è obbligatorio"]
     }
 });
 

--- a/backend/routes/candidature.js
+++ b/backend/routes/candidature.js
@@ -12,10 +12,10 @@ import {ensureAuthenticated, ensureAuthorized} from "../middleware/authMiddlewar
 const router = express.Router();
 
 // ensureAuthenticated: Richiede che l'utente sia autenticato.
-// ensureAuthorized(['candidato']): Richiede che l'utente autenticato sia di tipo 'candidato'.
+// ensureAuthorized(['candidato']): Richiede che l'utente autenticato sia di tipo 'candidato' (come da schema Utente.js).
 router.post("/" , ensureAuthenticated, ensureAuthorized(["candidato"]), creazioneCandidature);
 
-router.get("/lavoratore/:email" , ensureAuthenticated, ensureAuthorized(["candidato"]),visualizzazioneCandidatureFatte); //al massimo per pulizia cambiare in '/:email'
+router.get("/lavoratore" , ensureAuthenticated, ensureAuthorized(["candidato"]),visualizzazioneCandidatureFatte); // Rimosso :email dal path
 
 router.get("/annuncio/:postAnnunciId", ensureAuthenticated, ensureAuthorized(["azienda"]), visualizzaCandidaturePerAnnuncio);
 

--- a/backend/routes/postAnnunci.js
+++ b/backend/routes/postAnnunci.js
@@ -18,10 +18,11 @@ router.post('/', ensureAuthenticated, ensureAuthorized(['azienda']), pubblicaLav
 
 router.get('/', riceviLavoro); 
 
+// Specific route for 'miei-annunci' must come before the parameterized ':id' route
+router.get('/miei-annunci', ensureAuthenticated, ensureAuthorized(['azienda']), riceviLavoroDaAzienda);
+
 router.get('/:id', riceviLavoroDaId);
 
 router.delete('/:id', ensureAuthenticated, ensureAuthorized(['azienda']), rimuoviLavoroDaId);
-
-router.get('/miei-annunci', ensureAuthenticated, ensureAuthorized(['azienda']), riceviLavoroDaAzienda);
 
 export default router 

--- a/frontend/Bacheca/src/components/navigation/Navbar.jsx
+++ b/frontend/Bacheca/src/components/navigation/Navbar.jsx
@@ -2,8 +2,8 @@
 
 // Importa React per la creazione del componente.
 import React from 'react';
-// Importa Link (per la navigazione dichiarativa) e useNavigate (per la navigazione programmatica) da react-router-dom.
-import { Link, useNavigate } from 'react-router-dom';
+// Importa Link (per la navigazione dichiarativa), useNavigate (per la navigazione programmatica) e useLocation (per accedere alla route corrente) da react-router-dom.
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 // Importa l'hook personalizzato useAuth per accedere allo stato di autenticazione e ai dati dell'utente.
 import useAuth from '../../hooks/useAuth';
 // Importa il componente GoogleLoginButton.
@@ -19,6 +19,8 @@ const Navbar = () => {
   const { isAuthenticated, user, logout, isLoading } = useAuth();
   // Hook per la navigazione programmatica, utilizzato per reindirizzare dopo il logout.
   const navigate = useNavigate();
+  // Hook per ottenere la posizione corrente (route).
+  const location = useLocation();
 
   // Funzione per gestire il login con Google.
   const handleGoogleLogin = () => {
@@ -39,6 +41,9 @@ const Navbar = () => {
     }
   };
 
+  // Determina se la pagina corrente è la homepage.
+  const isHomePage = location.pathname === '/';
+
   // Struttura JSX del componente Navbar.
   // Utilizza classi Bootstrap per lo styling e la responsività.
   return (
@@ -47,82 +52,112 @@ const Navbar = () => {
     // - "navbar-expand-lg": per espandere la navbar su schermi grandi (large) e collassarla su schermi più piccoli.
     // - "navbar-dark bg-dark": per uno schema di colori scuro.
     // - "mb-4": margine inferiore (margin-bottom) di 4 unità Bootstrap.
-    <nav className="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+    // La classe "w-100" è stata aggiunta per rendere la navbar full-width.
+    <nav className="navbar navbar-expand-lg navbar-dark bg-dark mb-4 w-100">
       {/* Contenitore fluido per la navbar, occupa l'intera larghezza. */}
       <div className="container-fluid">
         {/* Brand/Logo della navbar, un Link che punta alla homepage. */}
         <Link className="navbar-brand" to="/">JobBoard</Link>
         {/* Pulsante "toggler" per la navbar su schermi piccoli (hamburger menu).
             Controlla il collasso del div con id "navbarNav". */}
-        <button
-          className="navbar-toggler"
-          type="button"
-          data-bs-toggle="collapse" // Attributo Bootstrap per attivare il collasso.
-          data-bs-target="#navbarNav" // ID dell'elemento da collassare/espandere.
-          aria-controls="navbarNav"
-          aria-expanded="false"
-          aria-label="Toggle navigation"
-        >
-          <span className="navbar-toggler-icon"></span> {/* Icona del toggler. */}
-        </button>
+        {!isHomePage && ( // Mostra il toggler solo se non siamo sulla homepage
+          <button
+            className="navbar-toggler"
+            type="button"
+            data-bs-toggle="collapse" // Attributo Bootstrap per attivare il collasso.
+            data-bs-target="#navbarNav" // ID dell'elemento da collassare/espandere.
+            aria-controls="navbarNav"
+            aria-expanded="false"
+            aria-label="Toggle navigation"
+          >
+            <span className="navbar-toggler-icon"></span> {/* Icona del toggler. */}
+          </button>
+        )}
         {/* Contenitore collassabile che contiene i link di navigazione. */}
-        <div className="collapse navbar-collapse" id="navbarNav">
-          {/* Lista non ordinata per i link di navigazione principali, allineati a sinistra ("me-auto"). */}
-          <ul className="navbar-nav me-auto mb-2 mb-lg-0">
-            {/* Elemento di lista per il link alla Home. */}
-            <li className="nav-item">
-              <Link className="nav-link" to="/">Home</Link>
-            </li>
-            {/* Elemento di lista per il link a "Tutti gli Annunci". */}
-            <li className="nav-item">
-              <Link className="nav-link" to="/annunci">Tutti gli Annunci</Link>
-            </li>
-            {/* Link condizionale: visualizzato solo se l'utente è autenticato E il suo userType è 'azienda'. */}
-            {isAuthenticated && user?.userType === 'azienda' && (
+        {/* Nasconde l'intero div se siamo sulla homepage */}
+        {!isHomePage && (
+          <div className="collapse navbar-collapse" id="navbarNav">
+            {/* Lista non ordinata per i link di navigazione principali, allineati a sinistra ("me-auto"). */}
+            <ul className="navbar-nav me-auto mb-2 mb-lg-0">
+              {/* Elemento di lista per il link alla Home. */}
               <li className="nav-item">
-                <Link className="nav-link" to="/dashboard-azienda">Dashboard Azienda</Link>
+                <Link className="nav-link" to="/">Home</Link>
               </li>
-            )}
-            {/* Link condizionale: visualizzato solo se l'utente è autenticato E il suo userType è 'applier'. */}
-            {isAuthenticated && user?.userType === 'applier' && (
-              <li className="nav-item">
-                <Link className="nav-link" to="/dashboard-applier">Dashboard Applier</Link>
-              </li>
-            )}
-          </ul>
-          {/* Sezione dei link allineati a destra (login/logout, info utente).
-              Viene renderizzata solo se lo stato di autenticazione non è in caricamento (!isLoading).
-              Questo previene un "flicker" dei pulsanti Login/Register mentre si verifica la sessione. */}
-          {!isLoading && (
-            <ul className="navbar-nav">
-              {/* Se l'utente è autenticato: */}
-              {isAuthenticated ? (
-                // Mostra un dropdown con il nome/email dell'utente e l'opzione di logout.
-                <li className="nav-item dropdown">
-                  {/* Link che attiva il dropdown Bootstrap. */}
-                  <a
-                    className="nav-link dropdown-toggle"
-                    href="#" // href="#" è comune per link che attivano solo JS.
-                    id="navbarDropdownMenuLink"
-                    role="button"
-                    data-bs-toggle="dropdown" // Attributo Bootstrap per il dropdown.
-                    aria-expanded="false"
-                  >
-                    {/* Mostra il displayName o l'email dell'utente, e il suo userType. */}
-                    {user?.displayName || user?.email} ({user?.userType})
-                  </a>
-                  {/* Menu del dropdown, allineato a destra ("dropdown-menu-end"). */}
-                  <ul className="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdownMenuLink">
-                    {/* Elemento del menu per il logout. È un pulsante stilizzato come dropdown-item. */}
-                    <li><button className="dropdown-item" onClick={handleLogout}>Logout</button></li>
-                  </ul>
+
+              {/* Pulsanti condizionali per tornare alle dashboard */}
+              {/* 1. Navbar alla route /annunci e /mie-candidature: bottone per Dashboard Candidato */}
+              {(location.pathname === '/annunci' || location.pathname === '/mie-candidature') && isAuthenticated && user?.tipoUtente === 'candidato' && (
+                <li className="nav-item">
+                  <Link className="nav-link" to="/dashboard-candidato">Dashboard Candidato</Link>
                 </li>
-              ) : (
-                      <GoogleLoginButton onClick={handleGoogleLogin} />
+              )}
+              {/* Link per tornare alla Dashboard Azienda */}
+              {(location.pathname === '/crea-annuncio' || location.pathname === '/dashboard-azienda/annunci') && isAuthenticated && user?.tipoUtente === 'azienda' && (
+                <li className="nav-item">
+                  <Link className="nav-link" to="/dashboard-azienda">Dashboard Azienda</Link>
+                </li>
+              )}
+
+              {/* Link "Tutti gli Annunci" */}
+              {/* Mostra "Tutti gli Annunci" se:
+                  - L'utente è sulla pagina /mie-candidature (specific requirement 2)
+                  - OPPURE l'utente non è su /dashboard-applier, /annunci, o /mie-candidature (general visibility)
+              */}
+              {(location.pathname === '/mie-candidature' ||
+               (!(location.pathname === '/dashboard-applier' || location.pathname === '/annunci' || location.pathname === '/mie-candidature'))) && (
+                <li className="nav-item">
+                  <Link className="nav-link" to="/annunci">Tutti gli Annunci</Link>
+                </li>
+              )}
+
+              {/* Link condizionali principali alle dashboard generiche (evitando duplicati con i link contestuali sopra) */}
+              {isAuthenticated && user?.tipoUtente === 'azienda' &&
+                !(location.pathname === '/crea-annuncio' || location.pathname === '/dashboard-azienda/annunci' || location.pathname === '/dashboard-azienda') && (
+                <li className="nav-item">
+                  <Link className="nav-link" to="/dashboard-azienda">Dashboard Azienda</Link>
+                </li>
+              )}
+              {isAuthenticated && user?.tipoUtente === 'candidato' &&
+                !(location.pathname === '/annunci' || location.pathname === '/mie-candidature' || location.pathname === '/dashboard-candidato') && ( // Updated path here
+                <li className="nav-item">
+                  <Link className="nav-link" to="/dashboard-candidato">Dashboard Candidato</Link>
+                </li>
               )}
             </ul>
-          )}
-        </div>
+            {/* Sezione dei link allineati a destra (login/logout, info utente).
+                Viene renderizzata solo se lo stato di autenticazione non è in caricamento (!isLoading).
+                Questo previene un "flicker" dei pulsanti Login/Register mentre si verifica la sessione. */}
+            {!isLoading && (
+              <ul className="navbar-nav">
+                {/* Se l'utente è autenticato: */}
+                {isAuthenticated ? (
+                  // Mostra un dropdown con il nome/email dell'utente e l'opzione di logout.
+                  <li className="nav-item dropdown">
+                    {/* Link che attiva il dropdown Bootstrap. */}
+                    <a
+                      className="nav-link dropdown-toggle"
+                      href="#" // href="#" è comune per link che attivano solo JS.
+                      id="navbarDropdownMenuLink"
+                      role="button"
+                      data-bs-toggle="dropdown" // Attributo Bootstrap per il dropdown.
+                      aria-expanded="false"
+                    >
+                      {/* Mostra il displayName o l'email dell'utente, e il suo tipoUtente. */}
+                      {user?.displayName || user?.email} ({user?.tipoUtente})
+                    </a>
+                    {/* Menu del dropdown, allineato a destra ("dropdown-menu-end"). */}
+                    <ul className="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdownMenuLink">
+                      {/* Elemento del menu per il logout. È un pulsante stilizzato come dropdown-item. */}
+                      <li><button className="dropdown-item" onClick={handleLogout}>Logout</button></li>
+                    </ul>
+                  </li>
+                ) : (
+                        <GoogleLoginButton onClick={handleGoogleLogin} />
+                )}
+              </ul>
+            )}
+          </div>
+        )}
       </div>
     </nav>
   );

--- a/frontend/Bacheca/src/pages/ApplierDashboardPage.jsx
+++ b/frontend/Bacheca/src/pages/ApplierDashboardPage.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 // Importa il componente Link da react-router-dom per la navigazione dichiarativa.
 import { Link } from 'react-router-dom';
 // Importa l'hook personalizzato useAuth per accedere ai dati dell'utente autenticato.
-import useAuth from '../hooks/useAuth';
+import useAuth from '../hooks/useAuth.js'; // Ensured .js extension and correct path
 
 // Definizione del componente funzionale ApplierDashboardPage.
 // Questa pagina serve come pannello di controllo per gli utenti di tipo 'applier' (candidati).
@@ -38,22 +38,21 @@ const ApplierDashboardPage = () => {
           <hr />
           {/* Contenitore per i pulsanti di azione, con classi Bootstrap per layout flex. */}
           <div className="d-grid gap-2 d-md-flex justify-content-md-start">
-            {/* Link alla pagina che elenca tutti gli annunci di lavoro ('/annunci').
-                Stilizzato come pulsante primario Bootstrap. Include un'icona. */}
-            <Link to="/annunci" className="btn btn-primary me-md-2 mb-2 mb-md-0">
-              <i className="bi bi-card-list me-2"></i>Sfoglia Tutti gli Annunci
-            </Link>
             {/* Link alla pagina dove l'utente può visualizzare le proprie candidature inviate ('/mie-candidature').
                 Stilizzato come pulsante informativo Bootstrap. Include un'icona. */}
-            <Link to="/mie-candidature" className="btn btn-info">
+            <Link to="/mie-candidature" className="btn btn-info me-md-2 mb-2 mb-md-0">
               <i className="bi bi-file-earmark-text me-2"></i>Le Mie Candidature
+            </Link>
+            {/* Bottone "Sfoglia Tutti gli Annunci" aggiunto qui */}
+            <Link to="/annunci" className="btn btn-primary">
+              <i className="bi bi-card-list me-2"></i>Sfoglia Tutti gli Annunci
             </Link>
           </div>
         </div>
         {/* Piè di pagina della card, con testo attenuato. */}
         <div className="card-footer text-muted">
           {/* Mostra il tipo di utente loggato, per conferma. */}
-          Tipo Utente: {user?.userType}
+          {user?.tipoUtente}
         </div>
       </div>
     </div>

--- a/frontend/Bacheca/src/pages/CompanyDashboardPage.jsx
+++ b/frontend/Bacheca/src/pages/CompanyDashboardPage.jsx
@@ -60,7 +60,7 @@ const CompanyDashboardPage = () => {
         {/* Piè di pagina della card, con testo attenuato. */}
         <div className="card-footer text-muted">
           {/* Mostra il tipo di utente loggato, per conferma. */}
-          Tipo Utente: {user?.userType}
+          {user?.tipoUtente}
         </div>
       </div>
     </div>

--- a/frontend/Bacheca/src/services/api/candidatureService.js
+++ b/frontend/Bacheca/src/services/api/candidatureService.js
@@ -15,10 +15,11 @@ export const getCandidaturePerAnnuncio = async (postAnnunciId) => {
 //da non riscrivere sogni volta URL e headers
 //Inoltre, se in futuro vuoi aggiungere autenticazione, intercettori o altre impostazioni, ti basta modificarle in un solo posto (apiClient.js) e tutte le chiamate API le useranno automaticamente.
 
-export const getCandidatureFatte = async (email) =>{
-    return apiClient.get(`/candidature/lavoratore/${email}`);
+// Modificato: L'endpoint backend ora usa l'ID utente dalla sessione, non più l'email nel path.
+export const getCandidatureFatte = async () =>{
+    return apiClient.get(`/candidature/lavoratore`); // Rimosso :email dal path
 };
-//RIVEDERE QUESTO SOPRA NEL CASO
+
 //La funzione si collega al backend inviando una richiesta
 //GET all'endpoint /candidature/lavoratore/email.
 //La parte ${email} nel template literal inserisce il valore dell’email direttamente nell’URL.


### PR DESCRIPTION
- Navbar: Hide 'Dashboard Azienda' link on /dashboard-azienda page.
- JobListingsPage: Display plain text 'Accedi Ora' for authenticated non-candidate users, and 'Accedi per candidarti' for non-authenticated users, instead of buttons.
- Navbar: Confirmed 'Dashboard Candidato' links point to '/dashboard-candidato'.
- MyApplications: Verified code for fetching applications is correct (parameter-less GET to /api/candidature/lavoratore). Persistent 404s are likely client-side caching or build issues.